### PR TITLE
runScript throws errors to GSStdOut

### DIFF
--- a/Glyphs remote scripts/Glyphs.py
+++ b/Glyphs remote scripts/Glyphs.py
@@ -39,6 +39,9 @@ class GSStdOut(NSObject):
 	def setWrite_(self, text):
 		print(text, end="")
 
+	def setWriteError_(self, text):
+		print(text, end="")
+
 
 def RunScript(code):
 	StdOut = GSStdOut.new()


### PR DESCRIPTION
so far, whenever you made the simplest error, runScript wasn't able to throw properly errors in the output (when you run the script from the terminal, with `Use system console for script output` unchecked). This should fix that.
<img width="727" alt="image" src="https://github.com/user-attachments/assets/ddc2e650-5201-4451-8c32-f30059b06820">
